### PR TITLE
update/add-required-dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='py-zabbix',
       author_email='alexey.dubkov@gmail.com',
       test_suite='tests',
       packages=['pyzabbix', 'zabbix'],
+      install_requires=['packaging'],
       tests_require=['mock'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import pip
+pip.main(['install', 'packaging'])
 from setuptools import setup
 from pyzabbix.version import __version__
 
@@ -12,7 +14,6 @@ setup(name='py-zabbix',
       author_email='alexey.dubkov@gmail.com',
       test_suite='tests',
       packages=['pyzabbix', 'zabbix'],
-      install_requires=['packaging'],
       tests_require=['mock'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This fixes error: `ModuleNotFoundError: No module named 'packaging'` when installing the module via pip